### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -3,6 +3,9 @@
 
 name: Go
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/fusion94/Go-FilamentSamples/security/code-scanning/1](https://github.com/fusion94/Go-FilamentSamples/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. Since the workflow does not perform any write operations, we can set the permissions to `contents: read` at the root level. This will apply the least privilege required for all jobs in the workflow.

The changes will be made to the `.github/workflows/go.yml` file:
1. Add a `permissions` block at the root level of the workflow, specifying `contents: read`.
2. Ensure no other permissions are granted unless explicitly required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
