### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-go
 
 name: Go
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/fusion94/Go-FilamentSamples/security/code-scanning/2](https://github.com/fusion94/Go-FilamentSamples/security/code-scanning/2)

To fix the issue, add a `permissions` block to the root of the workflow file. This block will explicitly define the permissions required for the workflow, limiting the `GITHUB_TOKEN` to `contents: read`. This ensures that the workflow adheres to the principle of least privilege while still functioning correctly.

The `permissions` block should be added immediately after the `name` key in the workflow file. No additional dependencies or changes are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
